### PR TITLE
fix: Accept multiple arguments for a registered command

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -163,7 +163,7 @@ function registerCommands(uri: Uri) {
   for (let { type, command, group } of INTERNAL_COMMANDS) {
     let internalName = `${type}.${command}`;
     let displayName = `${type} ${command}`;
-    let command$ = commands.registerCommand(internalName, async (args) => {
+    let command$ = commands.registerCommand(internalName, async (...args) => {
       let task = new Task(
         { type, command },
         TaskScope.Workspace,


### PR DESCRIPTION
<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

# Description

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

While diving into various fixes for the `Run test` code lens, I found that we didn't accept multiple arguments to the registered command. This change allows it to accept more than one argument.

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
