### PR TITLE
feat: Add compile command to handle Compile code lens

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -149,6 +149,7 @@ function getLspCommand(uri: Uri) {
 
 let INTERNAL_COMMANDS = [
   { type: "nargo", command: "test", group: TaskGroup.Test },
+  { type: "nargo", command: "compile", group: TaskGroup.Build },
 ];
 
 function registerCommands(uri: Uri) {
@@ -181,7 +182,7 @@ function registerCommands(uri: Uri) {
       // However, we still want to show the terminal when you run a test
       task.presentationOptions = {
         reveal: TaskRevealKind.Always,
-        panel: TaskPanelKind.Dedicated,
+        panel: TaskPanelKind.New,
         clear: true,
       };
 


### PR DESCRIPTION
<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

# Description

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Closes #27 <!-- Link to GitHub Issue -->
Ref https://github.com/noir-lang/noir/pull/2309

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

This adds a `nargo.compile` command that will be triggered via the `> Compile` code lens.

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
