### PR TITLE
feat: Add execute command to handle Execute code lens

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -150,6 +150,7 @@ function getLspCommand(uri: Uri) {
 let INTERNAL_COMMANDS = [
   { type: "nargo", command: "test", group: TaskGroup.Test },
   { type: "nargo", command: "compile", group: TaskGroup.Build },
+  { type: "nargo", command: "execute", group: TaskGroup.Build },
 ];
 
 function registerCommands(uri: Uri) {


### PR DESCRIPTION
<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

# Description

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Ref https://github.com/noir-lang/noir/pull/2330 <!-- Link to GitHub Issue -->

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

This adds a `nargo.execute` command that will be triggered via the `> Execute` code lens.

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
