### PR TITLE
chore: Separate Client into own class

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -81,11 +81,9 @@ export default class Client extends LanguageClient {
   }
 
   async start(): Promise<void> {
-    this.info(
-      `Starting LSP client using command: ${this.#command} ${this.#args.join(
-        " "
-      )}`
-    );
+    let command = this.#command;
+    let args = this.#args.join(" ");
+    this.info(`Starting LSP client using command: ${command} ${args}`);
 
     await super.start();
   }

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,0 +1,96 @@
+import { workspace, WorkspaceFolder, Uri, window, OutputChannel } from "vscode";
+
+import {
+  LanguageClient,
+  LanguageClientOptions,
+  ServerOptions,
+  TextDocumentFilter,
+} from "vscode-languageclient/node";
+
+import { extensionName, languageId } from "./constants";
+import findNargo from "./find-nargo";
+
+function globFromUri(uri: Uri, glob: string) {
+  // globs always need to use `/`
+  return `${uri.fsPath}${glob}`.replaceAll("\\", "/");
+}
+
+function getLspCommand(uri: Uri) {
+  let config = workspace.getConfiguration("noir", uri);
+
+  let lspEnabled = config.get<boolean>("enableLSP");
+
+  if (!lspEnabled) {
+    return;
+  }
+
+  let command = config.get<string | undefined>("nargoPath") || findNargo();
+
+  let flags = config.get<string | undefined>("nargoFlags") || "";
+
+  // Remove empty strings from the flags list
+  let args = ["lsp", ...flags.split(" ")].filter((arg) => arg !== "");
+
+  return [command, args] as const;
+}
+
+export default class Client extends LanguageClient {
+  #uri: Uri;
+  #command: string;
+  #args: string[];
+  #output: OutputChannel;
+
+  constructor(uri: Uri, workspaceFolder?: WorkspaceFolder) {
+    let outputChannel = window.createOutputChannel(extensionName, languageId);
+
+    let [command, args] = getLspCommand(uri);
+
+    let documentSelector: TextDocumentFilter[] = [];
+    if (workspaceFolder) {
+      documentSelector.push({
+        scheme: "file",
+        language: languageId,
+        // Glob starts with `/` because it just appends both segments
+        pattern: `${globFromUri(uri, "/**/*")}`,
+      });
+    } else {
+      documentSelector.push({
+        scheme: uri.scheme,
+        language: languageId,
+        pattern: `${globFromUri(uri, "")}`,
+      });
+    }
+
+    let clientOptions: LanguageClientOptions = {
+      documentSelector,
+      workspaceFolder,
+      outputChannel,
+    };
+
+    let serverOptions: ServerOptions = {
+      command,
+      args,
+    };
+
+    super(languageId, extensionName, serverOptions, clientOptions);
+
+    this.#uri = uri;
+    this.#command = command;
+    this.#args = args;
+    this.#output = outputChannel;
+  }
+
+  async start(): Promise<void> {
+    this.info(
+      `Starting LSP client using command: ${this.#command} ${this.#args.join(
+        " "
+      )}`
+    );
+
+    await super.start();
+  }
+
+  async dispose(timeout?: number): Promise<void> {
+    await super.dispose(timeout);
+  }
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,3 @@
+export let extensionName = "Noir Language Server";
+
+export let languageId = "noir";

--- a/src/find-nargo.ts
+++ b/src/find-nargo.ts
@@ -1,0 +1,16 @@
+import which from "which";
+
+const nargoBinaries = ["nargo"];
+
+export default function findNargo() {
+  for (const bin of nargoBinaries) {
+    try {
+      const nargo = which.sync(bin);
+      // If it didn't throw, we found a nargo binary
+      return nargo;
+    } catch (err) {
+      // Not found
+    }
+  }
+  throw new Error("Unable to locate any nargo binary. Did you install it?");
+}


### PR DESCRIPTION
<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

# Description

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

This refactors the client construction and startup so it can be shared between workspaces and files. It also becomes its own class that extends the LanguageClient so we can attach other items, such as the Test Controller in #33, that are disposed with the client.

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
