### PR TITLE
feat: add opcodes profile information

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,6 +4,7 @@
   },
   "cSpell.words": [
     "acir",
-    "brillig"
+    "brillig",
+    "nargo"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,9 @@
 {
   "[typescript]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
-  }
+  },
+  "cSpell.words": [
+    "acir",
+    "brillig"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "title": "Noir: Restart Language Server"
       },
       {
-        "command": "noir.profile.hide",
+        "command": "nargo.profile.hide",
         "title": "Noir: Hide Profile information"
       }
     ],

--- a/package.json
+++ b/package.json
@@ -32,6 +32,10 @@
       {
         "command": "noir.restart",
         "title": "Noir: Restart Language Server"
+      },
+      {
+        "command": "noir.profile.hide",
+        "title": "Noir: Hide Profile information"
       }
     ],
     "snippets": [

--- a/package.json
+++ b/package.json
@@ -75,13 +75,13 @@
     ],
     "keybindings": [{
       "command": "nargo.profile.hide",
-      "key": "shift+alt+cmd+n, shift+p",
+      "key": "shift+alt+ctrl+n, shift+p",
       "mac": "shift+alt+cmd+n shift+p",
       "when": "noir.profileInfoPresent"
     },
     {
       "command": "nargo.profile",
-      "key": "shift+alt+cmd+n p",
+      "key": "shift+alt+ctrl+n p",
       "mac": "shift+alt+cmd+n p"
     }],    
     "configuration": {

--- a/package.json
+++ b/package.json
@@ -35,9 +35,18 @@
       },
       {
         "command": "nargo.profile.hide",
-        "title": "Noir: Hide Profile information"
+        "title": "Noir: Hide Profile information",
+        "when": "noir.profileInfoPresent == true"
       }
     ],
+    "menus": {
+      "commandPalette": [
+        {
+          "command": "nargo.profile.hide",
+          "when": "noir.profileInfoPresent == true"
+        }
+      ]
+    },    
     "snippets": [
       {
         "language": "noir",
@@ -64,6 +73,17 @@
         "path": "./syntaxes/noir.tmLanguage.json"
       }
     ],
+    "keybindings": [{
+      "command": "nargo.profile.hide",
+      "key": "shift+alt+cmd+n, shift+p",
+      "mac": "shift+alt+cmd+n shift+p",
+      "when": "noir.profileInfoPresent"
+    },
+    {
+      "command": "nargo.profile",
+      "key": "shift+alt+cmd+n p",
+      "mac": "shift+alt+cmd+n p"
+    }],    
     "configuration": {
       "type": "object",
       "title": "Noir Language Server configuration",

--- a/src/EditorLineDecorationManager.ts
+++ b/src/EditorLineDecorationManager.ts
@@ -8,6 +8,7 @@ import {
   DecorationRangeBehavior,
   Position,
   ThemeColor,
+  commands,
 } from "vscode";
 import Client from "./client";
 
@@ -91,6 +92,9 @@ export class EditorLineDecorationManager extends Disposable {
     );
 
     updateDecorations(document, lineAccumulatedOpcodes);
+    
+    // Used to show Hide Commands in Pallette
+    commands.executeCommand('setContext', 'noir.profileInfoPresent', true);
   }
 
   hideDecorations() {
@@ -111,7 +115,7 @@ function updateDecorations(document, lineAccumulatedOpcodes: object) {
       decorators.push(lineDecorators);
 
       let hoverDecorators = lineInfo.ranges.map(({ range, countInfo }) => {
-        const hoverMessage = `// ${
+        const hoverMessage = `${
           countInfo.acir_size ? `${countInfo.acir_size} ACIR` : ""
         } ${
           countInfo.brillig_size ? `${countInfo.brillig_size} Brillig` : ""

--- a/src/EditorLineDecorationManager.ts
+++ b/src/EditorLineDecorationManager.ts
@@ -6,6 +6,8 @@ import {
   Range,
   TextEditorDecorationType,
   DecorationRangeBehavior,
+  Position,
+  ThemeColor,
 } from "vscode";
 import Client from "./client";
 
@@ -21,7 +23,6 @@ const decoration: TextEditorDecorationType =
 export class EditorLineDecorationManager extends Disposable {
   #didChangeActiveTextEditor: Disposable;
   lspClients: Map<string, Client>;
-  // activeClient: Client;
 
   constructor(lspClients: Map<string, Client>) {
     super(() => {});
@@ -29,105 +30,122 @@ export class EditorLineDecorationManager extends Disposable {
     this.lspClients = lspClients;
 
     window.onDidChangeActiveTextEditor((editor) => {
-      // this.updateActiveLspClient();
       this.displayAllTextDecorations();
     });
 
-    // window.onDidChangeTextEditorSelection(
-    //   (event: TextEditorSelectionChangeEvent) =>
-    //     this.didChangeTextEditorSelection(event)
-    // );
   }
 
   displayAllTextDecorations() {
     const document = window.activeTextEditor.document;
-    
+
     let workspaceFolder = workspace
       .getWorkspaceFolder(document.uri)
       .uri.toString();
     const activeClient = this.lspClients.get(workspaceFolder);
-    
 
-    const decorations = [];
-    activeClient.profileRunResult.opcodes_counts.forEach((element) => {
-      const spanInfo = element[0];
-      const countInfo = element[1];
-
-      const position = document.positionAt(
-        spanInfo.span.start
-      );
-
-        decorations.push({
-          range: document.lineAt(position.line).range,
-          content: `// ${countInfo.acir_size ? `${countInfo.acir_size} ACIR` : ""} ${
-            countInfo.brillig_size ? `${countInfo.brillig_size} ACIR` : ""
-          } opcodes`
-        });
+    let [fileIdKey, _] = (
+      Object.entries(activeClient.profileRunResult.file_map) as [string, any]
+    ).find(([fileId, fileElement]) => {
+      return fileElement.path === document.uri.path;
     });
-    updateDecorations(decorations);
 
+    let fileId = Number(fileIdKey);
+
+    const filteredResults = activeClient.profileRunResult.opcodes_counts.filter(
+      ([spanInfo, _]) => {
+        return spanInfo.file === fileId;
+      }
+    );
+
+    const lineAccumulatedOpcodes = filteredResults
+      .map(([spanInfo, countInfo]) => {
+        const startPosition = document.positionAt(spanInfo.span.start);
+        const endPosition = document.positionAt(spanInfo.span.end);
+
+        const range = new Range(startPosition, endPosition);
+
+        return { range, countInfo };
+      })
+      // Lets accumulate ranges by line numbers
+      .reduce((accumulator, { range, countInfo }) => {
+        let lineInfo = accumulator[range.end.line];
+        if (!lineInfo) {
+          lineInfo = { ranges: [] };
+        }
+        lineInfo.ranges.push({ range, countInfo });
+        accumulator[range.end.line] = lineInfo;
+        return accumulator;
+      }, {});
+
+    (Object.entries(lineAccumulatedOpcodes) as [number, any]).forEach(
+      ([lineNumber, lineInfo]) => {
+        lineInfo.lineOpcodes = lineInfo.ranges.reduce(
+          ({ acir, brillig }, { range, countInfo }) => {
+            acir = acir + countInfo.acir_size;
+            brillig = brillig + countInfo.brillig_size;
+            return { acir, brillig };
+          },
+          { acir: 0, brillig: 0 }
+        );
+      }
+    );
+
+    updateDecorations(document, lineAccumulatedOpcodes);
   }
 
   hideDecorations() {
     window.activeTextEditor.setDecorations(decoration, []);
   }
 
-  // didChangeTextEditorSelection(event) {
-  //   this.activeClient.profileRunResult.opcodes_counts.forEach((element) => {
-  //     const spanInfo = element[0];
-  //     const countInfo = element[1];
-
-  //     const position = event?.textEditor.document.positionAt(
-  //       spanInfo.span.start
-  //     );
-
-  //     if (position.line === event?.selections[0].anchor.line) {
-  //       console.log(position, countInfo);
-  //       updateDecorations(
-  //         event?.textEditor.document.lineAt(position.line).range,
-  //         `// ${countInfo.acir_size ? `${countInfo.acir_size} ACIR` : ""} ${
-  //           countInfo.brillig_size ? `${countInfo.brillig_size} ACIR` : ""
-  //         } opcodes`
-  //       );
-  //     } else {
-  //       clearDecorations();
-  //     }
-  //   });
-  // }
-
-  // updateActiveLspClient() {
-  //   const activeFileUri = window.activeTextEditor.document.uri;
-
-  //   let workspaceFolder = workspace
-  //     .getWorkspaceFolder(activeFileUri)
-  //     .uri.toString();
-  //   const activeClient = this.lspClients.get(workspaceFolder);
-  //   this.activeClient = activeClient;
-  // }
-
   dispose() {
     this.#didChangeActiveTextEditor.dispose();
   }
 }
 
-function updateDecorations(contentForRange: any[]) {
+function updateDecorations(document, lineAccumulatedOpcodes: object) {
+  const decorations = Object.entries(lineAccumulatedOpcodes)
+    .flatMap(([lineNumber, lineInfo]) => {
+      const decorators = [];
 
-  let decorations = contentForRange.map(({range, content}) => {
-    return {
-      range,
-      renderOptions: {
-        after: {
-          // backgroundColor: new ThemeColor('trailingLineBackgroundColor' ),
-          // color: new ThemeColor('trailingLineForegroundColor' ),
-          contentText: content,
-          fontWeight: "normal",
-          fontStyle: "normal",
-          // Pull the decoration out of the document flow if we want to be scrollable
-          textDecoration: `none; position: absolute;`,
-        },
-      },
-      }
-  });
+      const lineDecorators = lineDecorator(document, lineNumber, lineInfo);
+      decorators.push(lineDecorators);
+
+      let hoverDecorators = lineInfo.ranges.map(({ range, countInfo }) => {
+        const hoverMessage = `// ${
+          countInfo.acir_size ? `${countInfo.acir_size} ACIR` : ""
+        } ${
+          countInfo.brillig_size ? `${countInfo.brillig_size} Brillig` : ""
+        } opcodes`;
+        return {
+          range,
+          hoverMessage,
+        };
+      });
+      decorators.push(hoverDecorators);
+
+      return decorators;
+    })
+    .flat();
+
   window.activeTextEditor.setDecorations(decoration, decorations);
 }
-
+function lineDecorator(document: any, lineNumber: string, lineInfo: any) {
+  const range: Range = document.lineAt(Number(lineNumber)).range;
+  const lineContent = `// ${
+    lineInfo.lineOpcodes.acir ? `${lineInfo.lineOpcodes.acir} ACIR` : ""
+  } ${lineInfo.brillig_size ? `${lineInfo.brillig_size} ACIR` : ""} opcodes`;
+  const decorator = {
+    range,
+    renderOptions: {
+      after: {
+        backgroundColor: new ThemeColor('editorInlayHint.background' ),
+        color: new ThemeColor('editorInlayHint.foreground' ),
+        contentText: lineContent,
+        fontWeight: "normal",
+        fontStyle: "normal",
+        textDecoration: `none; position: absolute;`,
+      },
+    },
+  };
+  return decorator;
+}

--- a/src/EditorLineDecorationManager.ts
+++ b/src/EditorLineDecorationManager.ts
@@ -1,0 +1,133 @@
+import {
+  workspace,
+  Disposable,
+  window,
+  TextEditorSelectionChangeEvent,
+  Range,
+  TextEditorDecorationType,
+  DecorationRangeBehavior,
+} from "vscode";
+import Client from "./client";
+
+const decoration: TextEditorDecorationType =
+  window.createTextEditorDecorationType({
+    after: {
+      margin: "0 0 0 3em",
+      textDecoration: "none",
+    },
+    rangeBehavior: DecorationRangeBehavior.ClosedOpen,
+  });
+
+export class EditorLineDecorationManager extends Disposable {
+  #didChangeActiveTextEditor: Disposable;
+  lspClients: Map<string, Client>;
+  // activeClient: Client;
+
+  constructor(lspClients: Map<string, Client>) {
+    super(() => {});
+
+    this.lspClients = lspClients;
+
+    window.onDidChangeActiveTextEditor((editor) => {
+      // this.updateActiveLspClient();
+      this.displayAllTextDecorations();
+    });
+
+    // window.onDidChangeTextEditorSelection(
+    //   (event: TextEditorSelectionChangeEvent) =>
+    //     this.didChangeTextEditorSelection(event)
+    // );
+  }
+
+  displayAllTextDecorations() {
+    const document = window.activeTextEditor.document;
+    
+    let workspaceFolder = workspace
+      .getWorkspaceFolder(document.uri)
+      .uri.toString();
+    const activeClient = this.lspClients.get(workspaceFolder);
+    
+
+    const decorations = [];
+    activeClient.profileRunResult.opcodes_counts.forEach((element) => {
+      const spanInfo = element[0];
+      const countInfo = element[1];
+
+      const position = document.positionAt(
+        spanInfo.span.start
+      );
+
+        decorations.push({
+          range: document.lineAt(position.line).range,
+          content: `// ${countInfo.acir_size ? `${countInfo.acir_size} ACIR` : ""} ${
+            countInfo.brillig_size ? `${countInfo.brillig_size} ACIR` : ""
+          } opcodes`
+        });
+    });
+    updateDecorations(decorations);
+
+  }
+
+  hideDecorations() {
+    window.activeTextEditor.setDecorations(decoration, []);
+  }
+
+  // didChangeTextEditorSelection(event) {
+  //   this.activeClient.profileRunResult.opcodes_counts.forEach((element) => {
+  //     const spanInfo = element[0];
+  //     const countInfo = element[1];
+
+  //     const position = event?.textEditor.document.positionAt(
+  //       spanInfo.span.start
+  //     );
+
+  //     if (position.line === event?.selections[0].anchor.line) {
+  //       console.log(position, countInfo);
+  //       updateDecorations(
+  //         event?.textEditor.document.lineAt(position.line).range,
+  //         `// ${countInfo.acir_size ? `${countInfo.acir_size} ACIR` : ""} ${
+  //           countInfo.brillig_size ? `${countInfo.brillig_size} ACIR` : ""
+  //         } opcodes`
+  //       );
+  //     } else {
+  //       clearDecorations();
+  //     }
+  //   });
+  // }
+
+  // updateActiveLspClient() {
+  //   const activeFileUri = window.activeTextEditor.document.uri;
+
+  //   let workspaceFolder = workspace
+  //     .getWorkspaceFolder(activeFileUri)
+  //     .uri.toString();
+  //   const activeClient = this.lspClients.get(workspaceFolder);
+  //   this.activeClient = activeClient;
+  // }
+
+  dispose() {
+    this.#didChangeActiveTextEditor.dispose();
+  }
+}
+
+function updateDecorations(contentForRange: any[]) {
+
+  let decorations = contentForRange.map(({range, content}) => {
+    return {
+      range,
+      renderOptions: {
+        after: {
+          // backgroundColor: new ThemeColor('trailingLineBackgroundColor' ),
+          // color: new ThemeColor('trailingLineForegroundColor' ),
+          contentText: content,
+          fontWeight: "normal",
+          fontStyle: "normal",
+          // Pull the decoration out of the document flow if we want to be scrollable
+          textDecoration: `none; position: absolute;`,
+        },
+      },
+      }
+  });
+  window.activeTextEditor.setDecorations(decoration, decorations);
+}
+

--- a/src/EditorLineDecorationManager.ts
+++ b/src/EditorLineDecorationManager.ts
@@ -10,7 +10,7 @@ import {
   ThemeColor,
   commands,
 } from "vscode";
-import Client from "./client";
+import Client, { FileInfo, OpcodesCounts } from "./client";
 
 const decoration: TextEditorDecorationType =
   window.createTextEditorDecorationType({
@@ -47,10 +47,10 @@ export class EditorLineDecorationManager extends Disposable {
 
     // find file which we want to present hints for
     let [fileIdKey, _] = (
-      Object.entries(activeClient.profileRunResult.file_map) as [string, any]
+      Object.entries(activeClient.profileRunResult.file_map)
     ).find(([fileId, fileElement]) => {
       return fileElement.path === document.uri.path;
-    }) as [Number, any];
+    }) as [string, FileInfo];
 
     const fileId = Number(fileIdKey);
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -47,26 +47,26 @@ type NargoTests = {
   }[];
 };
 
-type FileId = number;
-type FileInfo = {
+export type FileId = number;
+export type FileInfo = {
   path: string;
   source: string;
 };
 
-type Span = {
+export type Span = {
   start: number;
   end: number;
 };
-type SpanInFile = {
+export type SpanInFile = {
   file: FileId;
   span: Span;
 };
-type OpcodesCounts = {
+export type OpcodesCounts = {
   acir_size: number;
   brillig_size: number;
 };
 
-type NargoProfileRunResult = {
+export type NargoProfileRunResult = {
   file_map: Map<FileId, FileInfo>;
   opcodes_counts: [[SpanInFile, OpcodesCounts]];
 };

--- a/src/client.ts
+++ b/src/client.ts
@@ -17,11 +17,10 @@ import {
 import {
   LanguageClient,
   LanguageClientOptions,
-  LinkedMap,
   ServerCapabilities,
   ServerOptions,
   TextDocumentFilter,
-  integer,
+
 } from "vscode-languageclient/node";
 
 import { extensionName, languageId } from "./constants";

--- a/src/client.ts
+++ b/src/client.ts
@@ -17,9 +17,11 @@ import {
 import {
   LanguageClient,
   LanguageClientOptions,
+  LinkedMap,
   ServerCapabilities,
   ServerOptions,
   TextDocumentFilter,
+  integer,
 } from "vscode-languageclient/node";
 
 import { extensionName, languageId } from "./constants";
@@ -45,6 +47,8 @@ type NargoTests = {
     range: Range;
   }[];
 };
+
+type NargoProfileRunResult = any;
 
 type RunTestResult = {
   id: string;
@@ -81,7 +85,7 @@ export default class Client extends LanguageClient {
   #command: string;
   #args: string[];
   #output: OutputChannel;
-
+  profileRunResult: NargoProfileRunResult;
   // This function wasn't added until vscode 1.81.0 so fake the type
   #testController: TestController & {
     invalidateTestResults?: (item: TestItem) => void;
@@ -173,6 +177,12 @@ export default class Client extends LanguageClient {
         }
       },
     });
+  }
+
+  async refreshProfileInfo() {
+    const response = await this.sendRequest<NargoProfileRunResult>("nargo/profile/run", { package: ""});
+
+    this.profileRunResult = response;
   }
 
   async #fetchTests() {

--- a/src/client.ts
+++ b/src/client.ts
@@ -47,7 +47,29 @@ type NargoTests = {
   }[];
 };
 
-type NargoProfileRunResult = any;
+type FileId = number;
+type FileInfo = {
+  path: string;
+  source: string;
+};
+
+type Span = {
+  start: number;
+  end: number;
+};
+type SpanInFile = {
+  file: FileId;
+  span: Span;
+};
+type OpcodesCounts = {
+  acir_size: number;
+  brillig_size: number;
+};
+
+type NargoProfileRunResult = {
+  file_map: Map<FileId, FileInfo>;
+  opcodes_counts: [[SpanInFile, OpcodesCounts]];
+};
 
 type RunTestResult = {
   id: string;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -172,7 +172,7 @@ function registerCommands(uri: Uri) {
   );
   commands$.push(profileCommand$);
   let hideProfileInformationCommand$ = commands.registerCommand(
-    "noir.profile.hide",
+    "nargo.profile.hide",
     async (...args) => {  
 
       editorLineDecorationManager.hideDecorations();

--- a/src/noir.ts
+++ b/src/noir.ts
@@ -1,0 +1,6 @@
+import { EditorLineDecorationManager } from "./EditorLineDecorationManager";
+import Client from "./client";
+
+export let lspClients: Map<string, Client> = new Map();
+
+export const editorLineDecorationManager = new EditorLineDecorationManager(lspClients);


### PR DESCRIPTION
Adds Command (with codelens `Profile` and key binding `shift+alt+ctrl+n p` to invoke profile command in LSP and display results as line decoration at the end, eg. `// 15 ACIR opcodes`. More detailed information is available on hover of individual code fragment (span).

<img width="458" alt="image" src="https://github.com/noir-lang/vscode-noir/assets/102518238/2d91007b-009f-451d-bf8d-826dc9fcd393">


Part of 
feat: Expose Profile information in vscode https://github.com/noir-lang/noir/issues/3501