### PR TITLE
feat: update grammar

### DIFF
--- a/syntaxes/noir.tmLanguage.json
+++ b/syntaxes/noir.tmLanguage.json
@@ -72,7 +72,15 @@
         },
         {
           "name": "constant.numeric.nr",
+          "match": "(\\-)?0x[0-9a-fA-F]+"
+        },
+        {
+          "name": "constant.numeric.nr",
           "match": "(\\-)?\\d+(\\.\\d+)?"
+        },
+        {
+          "name": "constant.language.nr",
+          "match": "\\b(true|false)\\b"
         }
       ]
     },
@@ -119,12 +127,15 @@
           }
         },
         {
-          "match": "\\b(let)\\s+([a-zA-Z_][a-zA-Z0-9_]*)",
+          "match": "\\b(let)\\s+(mut\\s+)?([a-zA-Z_][a-zA-Z0-9_]*)",
           "captures": {
             "1": {
               "name": "keyword.nr"
             },
             "2": {
+              "name": "keyword.nr"
+            },
+            "3": {
               "name": "variable.nr"
             }
           }
@@ -218,11 +229,11 @@
       "patterns": [
         {
           "name": "keyword.control.nr",
-          "match": "\\b(fn|mod|use|struct|if|else|for|constrain)\\b"
+          "match": "\\b(fn|impl|trait|type|mod|use|struct|if|else|for|constrain)\\b"
         },
         {
           "name": "keyword.nr",
-          "match": "\\b(global|comptime|pub|in|as|let|true|false)\\b"
+          "match": "\\b(global|comptime|unconstrained|distinct|pub|&mut|mut|self|in|as|let)\\b"
         }
       ]
     },
@@ -230,7 +241,7 @@
       "patterns": [
         {
           "name": "support.type.nr",
-          "match": "\\b((u|i)\\d+|str|bool|Field|Witness)\\b"
+          "match": "\\b((u|i)\\d+|str|bool|Field)\\b"
         },
         {
           "name": "support.type.nr",


### PR DESCRIPTION
<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

# Description

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR updates the grammar to handle various new language features which we've added. It's not perfect (The `&` in `&mut` doesn't get highlighted for some reason) but it's a big improvement over the current.

Changes:
- hex numbers now get consistently marked as a numeric literal rather than the letters remaining white.
- `impl`, `trait`, `type`, `unconstrained`, `distinct`, `pub`, `mut` and `self` are marked as keywords.
- `true` and `false` are now displayed as constants rather than as keywords.
- removed the `Witness` type as it does not exist.

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
