### PR TITLE
chore: Remove environment reference

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,6 @@ jobs:
     needs: release-please
     if: ${{ needs.release-please.outputs.tag-name }}
     runs-on: ubuntu-latest
-    environment: marketplace
     steps:
       - name: Setup Node.js
         uses: actions/setup-node@v3


### PR DESCRIPTION
Drop's environment reference from release workflow so that approvals through environments are not required.

Resolves:

Align plugin releases procedure to Noir main repo #61
