### PR TITLE
chore: Remove format on save override

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,8 +121,7 @@
     },
     "configurationDefaults": {
       "[noir]": {
-        "editor.defaultFormatter": "noir-lang.vscode-noir",
-        "editor.formatOnSave": true
+        "editor.defaultFormatter": "noir-lang.vscode-noir"
       }
     }
   },


### PR DESCRIPTION
# Description

## Problem\*

https://github.com/noir-lang/vscode-noir/pull/55 added the default configuration:
```json
"editor.formatOnSave":  true
``` 

Useful when users prefer auto-formatting.

Troublesome when users do not, as it overrides VS Code's global `editor.formatOnSave` setting (i.e. users cannot disable auto-formatting on Noir, even when the Format on Save option in VS Code's settings is unchecked).

## Summary\*

Remove the override.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
