### PR TITLE
feat(aztec): search for aztec-nargo on top of nargo bin

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -199,6 +199,10 @@ export default class Client extends LanguageClient {
     });
   }
 
+  get command(): string {
+    return this.#command;
+  }
+
   async refreshProfileInfo() {
     const response = await this.sendRequest<NargoProfileRunResult>('nargo/profile/run', { package: '' });
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -40,7 +40,7 @@ import {
 import { languageId } from './constants';
 import Client from './client';
 import findNargo from './find-nargo';
-import { lspClients, editorLineDecorationManager } from './noir';
+import { lspClients, editorLineDecorationManager, getNoirStatusBarItem, handleClientStartError } from './noir';
 
 const activeCommands: Map<string, Disposable> = new Map();
 
@@ -246,67 +246,78 @@ async function didOpenTextDocument(document: TextDocument): Promise<Disposable> 
   const uri = document.uri;
   let folder = workspace.getWorkspaceFolder(uri);
   let configHandler;
-  if (folder) {
-    // If we have nested workspace folders we only start a server on the outer most workspace folder.
-    folder = getOuterMostWorkspaceFolder(folder);
 
-    await addWorkspaceClient(folder);
-    registerWorkspaceCommands(folder);
+  try {
+    if (folder) {
+      // If we have nested workspace folders we only start a server on the outer most workspace folder.
+      folder = getOuterMostWorkspaceFolder(folder);
 
-    configHandler = mutex(folder.uri.toString(), async (e: ConfigurationChangeEvent) => {
-      if (e.affectsConfiguration('noir.nargoFlags', folder.uri)) {
-        disposeWorkspaceCommands(folder);
-        await removeWorkspaceClient(folder);
-        await addWorkspaceClient(folder);
-        registerWorkspaceCommands(folder);
+      await addWorkspaceClient(folder);
+
+      let currentLspClient = lspClients.get(folder.uri.toString());
+      let statusBarItem = getNoirStatusBarItem();
+      statusBarItem.tooltip = currentLspClient.command;
+      statusBarItem.show();
+
+      registerWorkspaceCommands(folder);
+
+      configHandler = mutex(folder.uri.toString(), async (e: ConfigurationChangeEvent) => {
+        if (e.affectsConfiguration('noir.nargoFlags', folder.uri)) {
+          disposeWorkspaceCommands(folder);
+          await removeWorkspaceClient(folder);
+          await addWorkspaceClient(folder);
+          registerWorkspaceCommands(folder);
+        }
+
+        if (e.affectsConfiguration('noir.nargoPath', folder.uri)) {
+          disposeWorkspaceCommands(folder);
+          await removeWorkspaceClient(folder);
+          await addWorkspaceClient(folder);
+          registerWorkspaceCommands(folder);
+        }
+
+        if (e.affectsConfiguration('noir.enableLSP', folder.uri)) {
+          await removeWorkspaceClient(folder);
+          await addWorkspaceClient(folder);
+        }
+      });
+    } else {
+      // We only want to handle `file:` and `untitled:` schemes because
+      // vscode sends `output:` schemes for markdown responses from our LSP
+      if (uri.scheme !== 'file' && uri.scheme !== 'untitled') {
+        return Disposable.from();
       }
 
-      if (e.affectsConfiguration('noir.nargoPath', folder.uri)) {
-        disposeWorkspaceCommands(folder);
-        await removeWorkspaceClient(folder);
-        await addWorkspaceClient(folder);
-        registerWorkspaceCommands(folder);
-      }
+      // Each file outside of a workspace gets it's own client
+      await addFileClient(uri);
+      registerFileCommands(uri);
 
-      if (e.affectsConfiguration('noir.enableLSP', folder.uri)) {
-        await removeWorkspaceClient(folder);
-        await addWorkspaceClient(folder);
-      }
-    });
-  } else {
-    // We only want to handle `file:` and `untitled:` schemes because
-    // vscode sends `output:` schemes for markdown responses from our LSP
-    if (uri.scheme !== 'file' && uri.scheme !== 'untitled') {
-      return Disposable.from();
+      configHandler = mutex(uri.toString(), async (e: ConfigurationChangeEvent) => {
+        if (e.affectsConfiguration('noir.nargoFlags', uri)) {
+          disposeFileCommands(uri);
+          await removeFileClient(uri);
+          await addFileClient(uri);
+          registerFileCommands(uri);
+        }
+
+        if (e.affectsConfiguration('noir.nargoPath', uri)) {
+          disposeFileCommands(uri);
+          await removeFileClient(uri);
+          await addFileClient(uri);
+          registerFileCommands(uri);
+        }
+
+        if (e.affectsConfiguration('noir.enableLSP', uri)) {
+          await removeFileClient(uri);
+          await addFileClient(uri);
+        }
+      });
     }
 
-    // Each file outside of a workspace gets it's own client
-    await addFileClient(uri);
-    registerFileCommands(uri);
-
-    configHandler = mutex(uri.toString(), async (e: ConfigurationChangeEvent) => {
-      if (e.affectsConfiguration('noir.nargoFlags', uri)) {
-        disposeFileCommands(uri);
-        await removeFileClient(uri);
-        await addFileClient(uri);
-        registerFileCommands(uri);
-      }
-
-      if (e.affectsConfiguration('noir.nargoPath', uri)) {
-        disposeFileCommands(uri);
-        await removeFileClient(uri);
-        await addFileClient(uri);
-        registerFileCommands(uri);
-      }
-
-      if (e.affectsConfiguration('noir.enableLSP', uri)) {
-        await removeFileClient(uri);
-        await addFileClient(uri);
-      }
-    });
+    return workspace.onDidChangeConfiguration(configHandler);
+  } catch (e) {
+    handleClientStartError(e);
   }
-
-  return workspace.onDidChangeConfiguration(configHandler);
 }
 
 async function didChangeWorkspaceFolders(event: WorkspaceFoldersChangeEvent) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -36,11 +36,13 @@ import {
   window,
   ProgressLocation,
 } from 'vscode';
+import os from 'os';
 
 import { languageId } from './constants';
 import Client from './client';
-import findNargo from './find-nargo';
-import { lspClients, editorLineDecorationManager, getNoirStatusBarItem, handleClientStartError } from './noir';
+import findNargo, { findNargoBinaries } from './find-nargo';
+import { lspClients, editorLineDecorationManager } from './noir';
+import { getNoirStatusBarItem, handleClientStartError } from './noir';
 
 const activeCommands: Map<string, Disposable> = new Map();
 
@@ -167,6 +169,15 @@ function registerCommands(uri: Uri) {
     editorLineDecorationManager.hideDecorations();
   });
   commands$.push(hideProfileInformationCommand$);
+
+  const selectNargoPathCommand$ = commands.registerCommand('nargo.config.path.select', async (..._args) => {
+    const homeDir = os.homedir();
+    const foundNargoBinaries = findNargoBinaries(homeDir);
+    const result = await window.showQuickPick(foundNargoBinaries, { placeHolder: 'Select the Nargo binary to use' });
+    const config = workspace.getConfiguration('noir', uri);
+    config.update('nargoPath', result);
+  });
+  commands$.push(selectNargoPathCommand$);
 
   activeCommands.set(file, Disposable.from(...commands$));
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -254,8 +254,8 @@ async function didOpenTextDocument(document: TextDocument): Promise<Disposable> 
 
       await addWorkspaceClient(folder);
 
-      let currentLspClient = lspClients.get(folder.uri.toString());
-      let statusBarItem = getNoirStatusBarItem();
+      const currentLspClient = lspClients.get(folder.uri.toString());
+      const statusBarItem = getNoirStatusBarItem();
       statusBarItem.tooltip = currentLspClient.command;
       statusBarItem.show();
 

--- a/src/find-nargo.ts
+++ b/src/find-nargo.ts
@@ -1,4 +1,4 @@
-import os, { homedir } from 'os';
+import os from 'os';
 import path from 'path';
 import fs from 'fs';
 import which from 'which';

--- a/src/find-nargo.ts
+++ b/src/find-nargo.ts
@@ -1,6 +1,6 @@
 import which from 'which';
 
-const nargoBinaries = ['nargo'];
+const nargoBinaries = ['nargo', 'aztec-nargo'];
 
 export default function findNargo() {
   for (const bin of nargoBinaries) {

--- a/src/find-nargo.ts
+++ b/src/find-nargo.ts
@@ -1,4 +1,4 @@
-import os from 'os';
+import os, { homedir } from 'os';
 import path from 'path';
 import fs from 'fs';
 import which from 'which';
@@ -6,45 +6,61 @@ import { NargoNotFoundError } from './noir';
 import { MarkdownString } from 'vscode';
 
 // List of possible nargo binaries to find on Path
-// We prioritize 'aztec-nargo' as more specialised case
-const nargoBinaries = ['aztec-nargo', 'nargo'];
+// We prioritize 'nargo' as the more standard version.
+const NARGO_BINARIES = ['nargo', 'aztec-nargo'];
 // List of possible default installations in users folder
-const nargoInstallLocationPostix = ['.aztec/bin/aztec-nargo', '.nargo/bin/nargo'];
+const NARGO_INSTALL_LOCATION_POSTFIXES = ['.nargo/bin/nargo', '.aztec/bin/aztec-nargo'];
 
-export default function findNargo() {
-  for (const bin of nargoBinaries) {
+function absoluteInstallLocationPaths(homeDir: string): string[] {
+  return NARGO_INSTALL_LOCATION_POSTFIXES.map((postfix) => path.join(homeDir, postfix)).filter((filePath) =>
+    fs.existsSync(filePath),
+  );
+}
+
+export function findNargoBinaries(homeDir: string): string[] {
+  // Note that JS sets maintain insertion order.
+  const nargoBinaryPaths: Set<string> = new Set();
+
+  for (const bin of NARGO_BINARIES) {
     try {
-      const nargo = which.sync(bin);
+      const path = which.sync(bin);
       // If it didn't throw, we found a nargo binary
-      return nargo;
+      nargoBinaryPaths.add(path);
     } catch (err) {
       // Not found
     }
   }
 
-  const homeDir = os.homedir();
   // So far we have not found installations on path
   // Let's check default installation locations
-  for (const postfix of nargoInstallLocationPostix) {
-    const filePath = path.join(homeDir, postfix);
-    if (fs.existsSync(filePath)) {
-      return filePath;
+  for (const filePath of absoluteInstallLocationPaths(homeDir)) {
+    nargoBinaryPaths.add(filePath);
+  }
+
+  return [...nargoBinaryPaths];
+}
+
+export default function findNargo() {
+  const homeDir = os.homedir();
+  const nargoBinaryPaths = findNargoBinaries(homeDir);
+
+  if (nargoBinaryPaths.length > 0) {
+    return nargoBinaryPaths[0];
+  } else {
+    const message = new MarkdownString();
+    message.appendText(`Could not locate any of\n`);
+    for (const nargoBinary of NARGO_BINARIES) {
+      message.appendMarkdown(`\`${nargoBinary}\``);
+      message.appendText(`\n`);
     }
-  }
 
-  const message = new MarkdownString();
-  message.appendText(`Could not locate any of\n`);
-  for (const nargoBinary of nargoBinaries) {
-    message.appendMarkdown(`\`${nargoBinary}\``);
-    message.appendText(`\n`);
-  }
+    message.appendText(`on \`$PATH\`, or one of default installation locations\n`);
+    for (const postfix of NARGO_INSTALL_LOCATION_POSTFIXES) {
+      const filePath = path.join(homeDir, postfix);
+      message.appendMarkdown(`\`${filePath}\``);
+      message.appendText(`\n`);
+    }
 
-  message.appendText(`on \`$PATH\`, or one of default installation locations\n`);
-  for (const postfix of nargoInstallLocationPostix) {
-    const filePath = path.join(homeDir, postfix);
-    message.appendMarkdown(`\`${filePath}\``);
-    message.appendText(`\n`);
+    throw new NargoNotFoundError(message);
   }
-
-  throw new NargoNotFoundError(message);
 }

--- a/src/noir.ts
+++ b/src/noir.ts
@@ -1,6 +1,46 @@
+import { MarkdownString, StatusBarAlignment, StatusBarItem, ThemeColor, window } from 'vscode';
 import { EditorLineDecorationManager } from './EditorLineDecorationManager';
 import Client from './client';
 
 export const lspClients: Map<string, Client> = new Map();
 
 export const editorLineDecorationManager = new EditorLineDecorationManager(lspClients);
+
+let noirStatusBarItem: StatusBarItem;
+
+export function getNoirStatusBarItem() {
+  if (noirStatusBarItem) {
+    return noirStatusBarItem;
+  }
+  // Create Nargo Status bar item, we only need one for lifetime of plugin
+  // we will show/update it depending on file user is working with
+  noirStatusBarItem = window.createStatusBarItem(StatusBarAlignment.Right, 100);
+  noirStatusBarItem.text = 'Nargo';
+
+  return noirStatusBarItem;
+}
+
+export class NargoNotFoundError extends Error {
+  constructor(markdownMessage?: MarkdownString) {
+    super(markdownMessage.value);
+
+    this.markdownMessage = markdownMessage;
+  }
+
+  markdownMessage: MarkdownString;
+}
+
+export function handleClientStartError(err: Error) {
+  if (err instanceof NargoNotFoundError) {
+    const backgroundColor = new ThemeColor('statusBarItem.errorBackground');
+    const foregroundColor = new ThemeColor('statusBarItem.errorForeground');
+
+    let statusBarItem = getNoirStatusBarItem();
+    statusBarItem.backgroundColor = backgroundColor;
+    statusBarItem.color = foregroundColor;
+    statusBarItem.tooltip = err.markdownMessage;
+    statusBarItem.show();
+  } else {
+    throw err;
+  }
+}

--- a/src/noir.ts
+++ b/src/noir.ts
@@ -35,7 +35,7 @@ export function handleClientStartError(err: Error) {
     const backgroundColor = new ThemeColor('statusBarItem.errorBackground');
     const foregroundColor = new ThemeColor('statusBarItem.errorForeground');
 
-    let statusBarItem = getNoirStatusBarItem();
+    const statusBarItem = getNoirStatusBarItem();
     statusBarItem.backgroundColor = backgroundColor;
     statusBarItem.color = foregroundColor;
     statusBarItem.tooltip = err.markdownMessage;

--- a/src/noir.ts
+++ b/src/noir.ts
@@ -16,6 +16,7 @@ export function getNoirStatusBarItem() {
   // we will show/update it depending on file user is working with
   noirStatusBarItem = window.createStatusBarItem(StatusBarAlignment.Right, 100);
   noirStatusBarItem.text = 'Nargo';
+  noirStatusBarItem.command = 'nargo.config.path.select';
 
   return noirStatusBarItem;
 }


### PR DESCRIPTION
Partialy resolves 

LSP to set nargo path based on nargo or aztec-nargo [#4233](https://github.com/noir-lang/noir/issues/4233),

Adds

<img width="247" alt="image" src="https://github.com/noir-lang/vscode-noir/assets/102518238/bf7f9e5c-cf95-4dd3-8a19-ce39edf3017d">

Status Bar item with information about nargo picked.

Indicates with colour and diagnostic message otherwise

![image](https://github.com/noir-lang/vscode-noir/assets/102518238/b67b2f4f-1ee2-4bc0-947d-f69947f94749)
