### PR TITLE
feat: add keyword highlighting for databus visibility keywords

### DIFF
--- a/syntaxes/noir.tmLanguage.json
+++ b/syntaxes/noir.tmLanguage.json
@@ -233,7 +233,7 @@
         },
         {
           "name": "keyword.nr",
-          "match": "\\b(global|comptime|unconstrained|distinct|pub|&mut|mut|self|in|as|let)\\b"
+          "match": "\\b(global|comptime|unconstrained|distinct|pub|call_data|return_data|&mut|mut|self|in|as|let)\\b"
         }
       ]
     },


### PR DESCRIPTION
<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

# Description

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR adds syntax highlighting for the new visibility keywords added in https://github.com/noir-lang/noir/pull/3508.

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
