### PR TITLE
feat: add `unsafe` keyword highlighting

### DIFF
--- a/syntaxes/noir.tmLanguage.json
+++ b/syntaxes/noir.tmLanguage.json
@@ -233,7 +233,7 @@
         },
         {
           "name": "keyword.nr",
-          "match": "\\b(global|comptime|unconstrained|distinct|pub|call_data|return_data|&mut|mut|self|in|as|let)\\b"
+          "match": "\\b(global|comptime|unsafe|unconstrained|distinct|pub|call_data|return_data|&mut|mut|self|in|as|let)\\b"
         }
       ]
     },


### PR DESCRIPTION
<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

# Description

## Problem\*

Blocked by https://github.com/noir-lang/noir/pull/4429

This PR adds syntax highlighting for the `unsafe` keyword

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
