### PR TITLE
feat: add `field` keyword highlighting

### DIFF
--- a/syntaxes/noir.tmLanguage.json
+++ b/syntaxes/noir.tmLanguage.json
@@ -241,7 +241,7 @@
       "patterns": [
         {
           "name": "support.type.nr",
-          "match": "\\b((u|i)\\d+|str|bool|Field)\\b"
+          "match": "\\b((u|i)\\d+|str|bool|field|Field)\\b"
         },
         {
           "name": "support.type.nr",


### PR DESCRIPTION
<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

# Description

## Problem\*

Blocked by https://github.com/noir-lang/noir/pull/3631

This PR adds syntax highlighting for the `field` keyword

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
