### PR TITLE
fix: update tooltip when selecting nargo binary

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -176,6 +176,8 @@ function registerCommands(uri: Uri) {
     const result = await window.showQuickPick(foundNargoBinaries, { placeHolder: 'Select the Nargo binary to use' });
     const config = workspace.getConfiguration('noir', uri);
     config.update('nargoPath', result);
+    const statusBarItem = getNoirStatusBarItem();
+    statusBarItem.tooltip = result;
   });
   commands$.push(selectNargoPathCommand$);
 


### PR DESCRIPTION
<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

# Description

## Problem\*

We're currently only updating the tooltip which shows the currently selected binary path when we open a new file. This PR forces this update whenever we update the nargo path.

Resolves <!-- Link to GitHub Issue -->

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
