### PR TITLE
fix: issue #79

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -91,12 +91,9 @@ function getLspCommand(uri: Uri) {
   }
 
   const command = config.get<string | undefined>('nargoPath') || findNargo();
-
-  const flags = config.get<string | undefined>('nargoFlags') || '';
-
-  // Remove empty strings from the flags list
-  const args = ['lsp', ...flags.split(' ')].filter((arg) => arg !== '');
-
+  
+  const args = ['lsp'];
+  
   return [command, args] as const;
 }
 


### PR DESCRIPTION
<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

# Description

## Problem

Resolves [issue #79](https://github.com/noir-lang/vscode-noir/issues/79)

## Summary

Delete 2 strings, which were adding nargo flags from Workspace config to `nargo lsp` command in function `getLspCommand`

## Addition

I'm junior in TS and vscode extension development, and this pull request is likely in need of additional testing.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
