### PR TITLE
Start debug session when receiving `nargo.debug.dap` command

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -171,6 +171,10 @@ function registerCommands(uri: Uri) {
     editorLineDecorationManager.hideDecorations();
   });
   commands$.push(hideProfileInformationCommand$);
+  const debugCommand$ = commands.registerCommand('nargo.debug.dap', async (..._args) => {
+    return commands.executeCommand('workbench.action.debug.start');
+  });
+  commands$.push(debugCommand$);
 
   const selectNargoPathCommand$ = commands.registerCommand('nargo.config.path.select', async (..._args) => {
     const homeDir = os.homedir();


### PR DESCRIPTION
# Description
Start a debug session when the extension receives the `nargo.debug.dap` command

## Summary\*

Use the built in `workbench.action.debug.start` vscode command to start the debug session

https://github.com/noir-lang/vscode-noir/assets/13237343/6e83d28c-126a-41ff-a23b-bc7ce9a50ccb

## Additional Context

This PR has its sibling in noir repo noir-lang/noir#5474

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
