### PR TITLE
chore: remove debug log

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -309,10 +309,6 @@ export default class Client extends LanguageClient {
   }
 
   async start(): Promise<void> {
-    const command = this.#command;
-    const args = this.#args.join(' ');
-    this.info(`Starting LSP client using command: ${command} ${args}`);
-
     await super.start();
   }
 


### PR DESCRIPTION
# Description

## Problem

The LSP client logs "Starting LSP client using command: ${command} ${args}" on every LSP interaction, not just when the LSP client starts, so that showing out in the output is confusing but also a bit distracting (especially if you are trying to see the actual messages that go between the client and server).

Also, now that we'll show (for now) comptime output in the logs, it's nice if we don't get this extra line for each "compilation".

## Summary

Removes that log line.

## Additional Context

When do we do releases of the extension?

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
