### PR TITLE
feat: expand `${workspaceFolder}` in `nargoPath` setting

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -23,7 +23,7 @@ import {
 } from 'vscode-languageclient/node';
 
 import { extensionName, languageId } from './constants';
-import findNargo from './find-nargo';
+import { getNargoPath } from './find-nargo';
 
 type NargoCapabilities = {
   nargo?: {
@@ -90,7 +90,7 @@ function getLspCommand(uri: Uri) {
     return;
   }
 
-  const command = config.get<string | undefined>('nargoPath') || findNargo();
+  const command = getNargoPath(uri);
 
   const flags = config.get<string | undefined>('nargoFlags') || '';
 

--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -15,7 +15,7 @@ import {
 } from 'vscode';
 
 import { spawn } from 'child_process';
-import findNargo from './find-nargo';
+import findNargo, { getNargoPath } from './find-nargo';
 import findNearestPackageFrom from './find-nearest-package';
 
 let outputChannel: OutputChannel;
@@ -37,10 +37,7 @@ export class NoirDebugAdapterDescriptorFactory implements DebugAdapterDescriptor
     _session: DebugSession,
     _executable: DebugAdapterExecutable,
   ): ProviderResult<DebugAdapterDescriptor> {
-    const config = workspace.getConfiguration('noir');
-
-    const configuredNargoPath = config.get<string | undefined>('nargoPath');
-    const nargoPath = configuredNargoPath || findNargo();
+    const nargoPath = getNargoPath();
 
     return new DebugAdapterExecutable(nargoPath, ['dap']);
   }
@@ -84,8 +81,7 @@ class NoirDebugConfigurationProvider implements DebugConfigurationProvider {
     config: DebugConfiguration,
     _token?: CancellationToken,
   ): ProviderResult<DebugConfiguration> {
-    const workspaceConfig = workspace.getConfiguration('noir');
-    const nargoPath = workspaceConfig.get<string | undefined>('nargoPath') || findNargo();
+    const nargoPath = getNargoPath();
 
     outputChannel.clear();
 

--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -1,7 +1,6 @@
 import {
   debug,
   window,
-  workspace,
   DebugAdapterDescriptorFactory,
   DebugSession,
   DebugAdapterExecutable,
@@ -15,7 +14,7 @@ import {
 } from 'vscode';
 
 import { spawn } from 'child_process';
-import findNargo, { getNargoPath } from './find-nargo';
+import { getNargoPath } from './find-nargo';
 import findNearestPackageFrom from './find-nearest-package';
 
 let outputChannel: OutputChannel;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -42,7 +42,7 @@ import { activateDebugger } from './debugger';
 
 import { languageId } from './constants';
 import Client from './client';
-import findNargo, { findNargoBinaries, getNargoPath } from './find-nargo';
+import { findNargoBinaries, getNargoPath } from './find-nargo';
 import { lspClients, editorLineDecorationManager } from './noir';
 import { getNoirStatusBarItem, handleClientStartError } from './noir';
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -42,7 +42,7 @@ import { activateDebugger } from './debugger';
 
 import { languageId } from './constants';
 import Client from './client';
-import findNargo, { findNargoBinaries } from './find-nargo';
+import findNargo, { findNargoBinaries, getNargoPath } from './find-nargo';
 import { lspClients, editorLineDecorationManager } from './noir';
 import { getNoirStatusBarItem, handleClientStartError } from './noir';
 
@@ -113,7 +113,7 @@ function registerCommands(uri: Uri) {
   const file = uri.toString();
   const config = workspace.getConfiguration('noir', uri);
 
-  const nargoPath = config.get<string | undefined>('nargoPath') || findNargo();
+  const nargoPath = getNargoPath(uri);
 
   const nargoFlags = config.get<string | undefined>('nargoFlags') || [];
 

--- a/src/find-nargo.ts
+++ b/src/find-nargo.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import fs from 'fs';
 import which from 'which';
 import { NargoNotFoundError } from './noir';
-import { MarkdownString } from 'vscode';
+import { MarkdownString, Uri, workspace } from 'vscode';
 
 // List of possible nargo binaries to find on Path
 // We prioritize 'nargo' as the more standard version.
@@ -63,4 +63,16 @@ export default function findNargo() {
 
     throw new NargoNotFoundError(message);
   }
+}
+
+export function getNargoPath(uri: Uri | undefined = undefined): string {
+  const config = workspace.getConfiguration('noir', uri);
+  let nargoPath = config.get<string | undefined>('nargoPath');
+  if (nargoPath === undefined) {
+    return findNargo();
+  }
+
+  nargoPath = nargoPath.replace(/\${workspaceFolder}/g, workspace.workspaceFolders[0].uri.fsPath);
+
+  return nargoPath;
 }


### PR DESCRIPTION
# Description

## Problem

Asked by Palla, it seems it'll be useful to use in Aztec-Packages.

## Summary

VSCode doesn't automatically expand variables in settings so some plugins do it. There's no convention about which names to use but at least the cmake plugin uses `workspaceFolder` for the workspace folder, and that's probably the most useful one to have to configure `nargo` relative to it... so that's just what this PR does.

## Additional Context

After merging this PR we'd probably need a new release so it can be used.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
