### PR TITLE
feat: some syntax highlighting improvements

### DIFF
--- a/syntaxes/noir.tmLanguage.json
+++ b/syntaxes/noir.tmLanguage.json
@@ -270,15 +270,15 @@
     "--struct-content": {
       "patterns": [
         {
-          "begin": "[a-zA-Z_][a-zA-Z0-9_]*",
-          "end": "([a-zA-Z_][a-zA-Z0-9_]*)|,",
-          "beginCaptures": {
-            "0": {
-              "name": "support.type.property-name.nr"
-            }
-          },
-          "endCaptures": {
+          "match": "(pub|pub\\(crate\\))?\\s*([a-zA-Z_][a-zA-Z0-9_]*)\\s*:\\s*([a-zA-Z_][a-zA-Z0-9_]*)",
+          "captures": {
             "1": {
+              "name": "keyword.nr"
+            },
+            "2": {
+              "name": "support.type.property-name.nr"
+            },
+            "3": {
               "name": "support.type.nr"
             }
           },

--- a/syntaxes/noir.tmLanguage.json
+++ b/syntaxes/noir.tmLanguage.json
@@ -99,8 +99,7 @@
           },
           "patterns": [
             {
-              "match": "[a-zA-Z_(::)][a-zA-Z0-9_]*",
-              "name": "support.type.nr"
+              "include": "#code"
             }
           ]
         },

--- a/syntaxes/noir.tmLanguage.json
+++ b/syntaxes/noir.tmLanguage.json
@@ -233,7 +233,7 @@
         },
         {
           "name": "keyword.nr",
-          "match": "\\b(global|comptime|quote|unsafe|unconstrained|pub|&mut|mut|self|in|as|let)\\b"
+          "match": "\\b(global|comptime|quote|unsafe|unconstrained|pub|crate|&mut|mut|self|in|as|let)\\b"
         }
       ]
     },

--- a/syntaxes/noir.tmLanguage.json
+++ b/syntaxes/noir.tmLanguage.json
@@ -248,11 +248,18 @@
           "match": "\\b(_*[A-Z][a-zA-Z0-9_]*|[a-zA-Z_][a-zA-Z0-9_]*::)\\b"
         },
         {
-          "begin": "\\b([a-z_][a-zA-Z0-9_]*)\\s*\\(",
+          "begin": "\\b([a-z_][a-zA-Z0-9_]*)\\s*(::<(.*)>\\s*)?\\(",
           "end": "\\)",
           "beginCaptures": {
             "1": {
               "name": "support.function.nr"
+            },
+            "2": {
+              "patterns": [
+                {
+                  "include": "#code"
+                }
+              ]
             }
           },
           "patterns": [


### PR DESCRIPTION
# Description

## Problem

Resolves #89
Resolves #90

## Summary

A few things here.

### `crate` is now highlighted

Before:

![image](https://github.com/user-attachments/assets/27138550-e911-4c34-b74a-54e1dba81b74)

After:

![image](https://github.com/user-attachments/assets/86ff59c8-0ed3-498f-a0ab-5b96b3d46450)

### Struct members visibility is now highlighted

Before:

![image](https://github.com/user-attachments/assets/24f5b69c-c80d-4c91-9fcc-ccca0c4aa6f5)

After:

![image](https://github.com/user-attachments/assets/aa67b2e2-909a-43a4-8eb5-d426d5318066)

### Calls with turbofish are colored the same way as calls

Before:

![image](https://github.com/user-attachments/assets/06156c28-0ba4-4033-915a-51a67a90905b)

After:

![image](https://github.com/user-attachments/assets/b97b6a20-8155-46b0-9ceb-d5fade753367)

### Comments inside `use` are highlighted

Before:

![image](https://github.com/user-attachments/assets/37b22999-9e2c-4476-b19c-5176cd4639df)

After:

![image](https://github.com/user-attachments/assets/f18d862a-6f32-447f-aa37-8f8792a95c05)

## Additional Context


# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
