### PR TITLE
chore: don't output capabilities to Noir Langauge Server output

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -165,7 +165,6 @@ export default class Client extends LanguageClient {
     this.registerFeature({
       fillClientCapabilities: () => {},
       initialize: (capabilities: ServerCapabilities & NargoCapabilities) => {
-        outputChannel.appendLine(`${JSON.stringify(capabilities)}`);
         if (typeof capabilities.nargo?.tests !== 'undefined') {
           this.#testController = tests.createTestController(
             // We prefix with our ID namespace but we also tie these to the URI since they need to be unique


### PR DESCRIPTION
# Description

## Problem

There's debug output that goes into the Noir Language Server output:

![image](https://github.com/user-attachments/assets/e2adf43d-0b1a-4cdd-ac18-5a5cf4c57f4d)

When debugging the extension using LSP, or just when trying to look into the output of comptime `println`, that output sometimes gets in the way.

## Summary

Removes that debug output.

## Additional Context

I wanted to get this done before the next release, because it's a minor thing so it can be done quickly.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
