### PR TITLE
feat: better syntax highlighting for strings

### DIFF
--- a/syntaxes/noir.tmLanguage.json
+++ b/syntaxes/noir.tmLanguage.json
@@ -52,17 +52,15 @@
     },
     "strings": {
       "name": "string.quoted.double.nr",
-      "match": "\"(.*?)(\n|(?<!\\\\)\")",
-      "captures": {
-        "1": {
-          "patterns": [
-            {
-              "name": "constant.character.escape.nr",
-              "match": "\\\\."
-            }
-          ]
-        }
-      }
+      "begin": "\"",
+      "end": "\"",
+      "patterns": [{
+        "include": "#escapes"
+      }]
+    },
+    "escapes": {
+      "name": "constant.character.escape.nr",
+      "match": "\\\\."
     },
     "numeric": {
       "patterns": [

--- a/syntaxes/noir.tmLanguage.json
+++ b/syntaxes/noir.tmLanguage.json
@@ -51,16 +51,51 @@
       ]
     },
     "strings": {
-      "name": "string.quoted.double.nr",
-      "begin": "\"",
-      "end": "\"",
-      "patterns": [{
-        "include": "#escapes"
-      }]
+      "patterns": [
+        {
+          "name": "string.quoted.double.nr",
+          "begin": "\"",
+          "end": "\"",
+          "patterns": [
+            {
+              "include": "#string-escapes"
+            }
+          ]
+        },
+        {
+          "name": "string.interpolated.nr",
+          "begin": "f\"",
+          "end": "\"",
+          "patterns": [
+            {
+              "include": "#interpolated-string-escapes"
+            },
+            {
+              "include": "#interpolations"
+            }
+          ]
+        }
+      ]
     },
-    "escapes": {
+    "string-escapes": {
       "name": "constant.character.escape.nr",
       "match": "\\\\."
+    },
+    "interpolated-string-escapes": {
+      "name": "constant.character.escape.nr",
+      "match": "\\\\.|{{|}}"
+    },
+    "interpolations": {
+      "match": "({)[^\"{}]*(})",
+      "name": "variable.other.nr",
+      "captures": {
+        "1": {
+          "name": "constant.character.nr"
+        },
+        "2": {
+          "name": "constant.character.nr"
+        }
+      }
     },
     "numeric": {
       "patterns": [

--- a/syntaxes/noir.tmLanguage.json
+++ b/syntaxes/noir.tmLanguage.json
@@ -63,6 +63,21 @@
           ]
         },
         {
+          "name": "string.quoted.double.nr",
+          "begin": "r(#*)\"",
+          "end": "\"(\\1)",
+          "beginCaptures": {
+            "1": {
+              "name": "string.quoted.byte.raw.nr"
+            }
+          },
+          "endCaptures": {
+            "1": {
+              "name": "string.quoted.byte.raw.nr"
+            }
+          }
+        },
+        {
           "name": "string.interpolated.nr",
           "begin": "f\"",
           "end": "\"",


### PR DESCRIPTION
# Description

## Problem

Resolves #50

## Summary

A few things here.

### Multiline format strings are correctly hihglighted

Before:

![image](https://github.com/user-attachments/assets/cf62de9e-d6ac-42e6-843e-d2fd192f664f)

After:

![image](https://github.com/user-attachments/assets/2251c0d2-0024-4ab6-ad83-878a7f0a4225)

### Format string interpolation is highlighted

Before:

![image](https://github.com/user-attachments/assets/ad4000a9-066c-4a5f-bf08-a8c9240f4685)

After:

![image](https://github.com/user-attachments/assets/e064da8b-1810-4ce6-966c-ab81dc771715)

### Raw strings are highlighted

Before:

![image](https://github.com/user-attachments/assets/9228aaeb-c6f5-496d-8ebe-fb887b8dc4e1)

After:

![image](https://github.com/user-attachments/assets/a36be6dd-7053-46cd-a54e-3602a58b075d)

## Additional Context

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
