### PR TITLE
fix: find nargo in path if `nargoPath` is blank

### DIFF
--- a/src/find-nargo.ts
+++ b/src/find-nargo.ts
@@ -68,7 +68,7 @@ export default function findNargo() {
 export function getNargoPath(uri: Uri | undefined = undefined): string {
   const config = workspace.getConfiguration('noir', uri);
   let nargoPath = config.get<string | undefined>('nargoPath');
-  if (nargoPath === undefined) {
+  if (nargoPath === undefined || nargoPath.trim().length == 0) {
     return findNargo();
   }
 


### PR DESCRIPTION
# Description

## Problem

Resolves an issue where if `nargoPath` was empty it wouldn't pick up `nargo` in PATH.

## Summary

## Additional Context

I don't know how it used to work. Maybe by default it starts in `undefined`, but then if you change it and erase it it ends up being an empty string.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
