### PR TITLE
feat(codelens): trigger debugger on 'Debug test' command (#3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,6 +134,16 @@
                 "type": "boolean",
                 "description": "Skips variables debugging instrumentation of code, making debugging less convenient but the resulting binary smaller and closer to production",
                 "default": false
+              },
+              "testName": {
+                "type": "string",
+                "description": "Optional test name to debug",
+                "default": null
+              },
+              "oracleResolver": {
+                "type": "string",
+                "description": "JSON RPC url to solve oracle calls",
+                "default": null
               }
             }
           }

--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -70,6 +70,8 @@ class NoirDebugConfigurationProvider implements DebugConfigurationProvider {
       proverName: config.proverName || `Prover`,
       generateAcir: config.generateAcir || false,
       skipInstrumentation: config.skipInstrumentation || false,
+      testName: config.testName,
+      oracleResolver: config.oracleResolver,
     };
 
     return resolvedConfig;
@@ -111,6 +113,11 @@ class NoirDebugConfigurationProvider implements DebugConfigurationProvider {
       preflightArgs.push(config.package);
     }
 
+    if (config.testName) {
+      preflightArgs.push(`--preflight-test-name`);
+      preflightArgs.push(config.testName);
+    }
+
     if (config.generateAcir) {
       preflightArgs.push(`--preflight-generate-acir`);
     }
@@ -141,6 +148,11 @@ class NoirDebugConfigurationProvider implements DebugConfigurationProvider {
       throw new Error(`Error launching debugger. Please inspect the Output pane for more details.`);
     } else {
       outputChannel.appendLine(`Starting debugger session...`);
+      if (config.oracleResolver) {
+        outputChannel.appendLine(`Using oracle resolver target ${config.oracleResolver}`);
+      } else {
+        outputChannel.appendLine(`No oracle resolver set`);
+      }
     }
 
     return config;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -35,6 +35,7 @@ import {
   TaskGroup,
   ProcessExecution,
   ProgressLocation,
+  debug,
 } from 'vscode';
 import os from 'os';
 
@@ -174,7 +175,24 @@ function registerCommands(uri: Uri) {
   const debugCommand$ = commands.registerCommand('nargo.debug.dap', async (..._args) => {
     return commands.executeCommand('workbench.action.debug.start');
   });
+
   commands$.push(debugCommand$);
+  const debugTestCommand$ = commands.registerCommand('nargo.debug.test', async (...args) => {
+    const exactIndex = args.indexOf('--exact');
+    const testName = args.at(exactIndex + 1);
+    const oracleResolver = process.env['TXE_TARGET'];
+    const workspaceFolder = workspace.getWorkspaceFolder(uri);
+    await debug.startDebugging(workspaceFolder, {
+      type: 'noir',
+      request: 'launch',
+      name: 'Noir binary package',
+      projectFolder: '${workspaceFolder}',
+      proverName: 'Prover',
+      ...(testName && { testName }),
+      ...(oracleResolver && { oracleResolver }),
+    });
+  });
+  commands$.push(debugTestCommand$);
 
   const selectNargoPathCommand$ = commands.registerCommand('nargo.config.path.select', async (..._args) => {
     const homeDir = os.homedir();


### PR DESCRIPTION

# Description
* trigger dap debugger when receiving `nargo.debug.test` command
* add new `testName` and `oracleResolver` fields to launch configuration

https://github.com/user-attachments/assets/d0186a1a-49e8-44ec-99ce-d57bd633fd64

## Problem\*

related to noir-lang/noir#5208


# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
