### PR TITLE
feat: allow running `nargo expand`

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,10 @@
         "command": "nargo.profile.hide",
         "title": "Noir: Hide Profile information",
         "when": "noir.profileInfoPresent == true"
+      },
+      {
+        "command": "nargo.expand",
+        "title": "Noir: `nargo expand` on current package"
       }
     ],
     "menus": {
@@ -46,6 +50,10 @@
         {
           "command": "nargo.profile.hide",
           "when": "noir.profileInfoPresent == true"
+        },
+        {
+          "command": "nargo.expand",
+          "when": "inNoirProject"
         }
       ]
     },


### PR DESCRIPTION
# Description

## Problem

No issue, just something nice to have: allow invoking `nargo expand` via LSP.

## Summary

Goes together with https://github.com/noir-lang/noir/pull/9012

This works similar to Rust Analyzer's "expand macro", except that in our case the entire crate's contents are put in a new document.

Here's it working with a simple file:

![lsp-nargo-expand-simple](https://github.com/user-attachments/assets/1284b82a-1e8b-4ad6-bb19-f3252b34ff4b)

Here's with one of Aztec's contracts:

![lsp-nargo-expand-contract](https://github.com/user-attachments/assets/c918c468-310a-4a49-b377-c7f2a73aa9dc)

## Additional Context

In the future we could add another comment to expand the crate but only show the contents of, for example, the current module. But for now this command alone is good enough because you can make a code change, re-run the command and it'll update the document's content in-place so if you scrolled down to where you had interesting stuff to see you'll see the update you wanted to see.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
