### PR TITLE
feat: `while` and other syntax highlighting

### DIFF
--- a/syntaxes/noir.tmLanguage.json
+++ b/syntaxes/noir.tmLanguage.json
@@ -324,10 +324,14 @@
     "--struct-content": {
       "patterns": [
         {
-          "match": "(pub|pub\\(crate\\))?\\s*([a-zA-Z_][a-zA-Z0-9_]*)\\s*:\\s*(.+)",
+          "match": "(pub|pub\\(.+\\))?\\s*([a-zA-Z_][a-zA-Z0-9_]*)\\s*:\\s*(.+)",
           "captures": {
             "1": {
-              "name": "keyword.nr"
+              "patterns": [
+                {
+                  "include": "#code"
+                }
+              ]
             },
             "2": {
               "name": "support.type.property-name.nr"


### PR DESCRIPTION
# Description

## Problem

Something noted by Nico and other things I noticed for a while.

## Summary

### `while` wasn't colored

Before:

<img width="214" height="131" alt="image" src="https://github.com/user-attachments/assets/f53d682f-4f52-4f6e-b696-c74638f369ff" />

After:

<img width="221" height="161" alt="image" src="https://github.com/user-attachments/assets/e5968a63-d0b5-421a-a9c5-e26aefc50131" />

### Struct field types sometimes weren't properly colored

Before:

<img width="347" height="89" alt="image" src="https://github.com/user-attachments/assets/6ff6b589-ba2d-4a92-9eaf-7bf5f3c11206" />

After:

<img width="354" height="91" alt="image" src="https://github.com/user-attachments/assets/4386e08c-5886-4ed6-91ea-2fda19eeee75" />

### Struct fields weren't properly colored while visibility was being typed out

Before:

<img width="264" height="86" alt="image" src="https://github.com/user-attachments/assets/46c68d26-0098-49e3-a750-253dc0cedb79" />

After:

<img width="257" height="76" alt="image" src="https://github.com/user-attachments/assets/35f4f5e3-ecf0-4559-acd4-989b524ade6f" />

## Additional Context


# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
